### PR TITLE
Switching custom prev and next to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 [![NPM](https://img.shields.io/npm/v/react-tabletrim.svg)](https://www.npmjs.com/package/react-tabletrim) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![ponysmith](https://circleci.com/gh/ponysmith/react-tabletrim.svg?style=shield)](<https://app.circleci.com/github/ponysmith/react-tabletrim/pipelines>)
 
-**react-tabletrim** makes data tables more responsive by allowing you to "trim" the table at smaller widths. When the table is trimmed, the table is reduced to two columns. The **sticky** column is always shown and is always printed as the first column. The second column is the **active** column. The active column can be changed via several optional built-in control elements or by manually setting/updating the `activeCol` prop on the `TableTrim` component.
+
+
+**TableTrim** makes data tables more responsive by allowing you to "trim" the table at smaller widths. When the table is trimmed, the table is reduced to two columns. The **sticky** column is always shown and is always printed as the first column. The second column is the **active** column. The active column can be changed via several optional built-in control elements or by manually setting/updating the `activeCol` prop on the `TableTrim` component.
+
+Visit [http://tabletrim.ponysmith.com](http://tabletrim.ponysmith.com) for more documentation and examples.
 
 ## Install
 
@@ -66,21 +70,22 @@ For **TableTrim** to function properly, both the `header` and `body` objects mus
 ### Optional `props`
 In addition to the required `data` prop, **TableTrim** supports a handful of optional props to customize the behavior of the component. The optional props are detailed below:
 
-| Prop | Default | Description |
-|------|---------|-------------|
-| `isTrimmed` | `false` | Sets whether the table is currently trimmed |
-| `stickyCol` | `0` | Set the column index which should always be visible when the table is trimmed. |
-| `activeCol` | `1` | Sets the default active column, or changes the currently active column. |
-| `autoTrimEnabled` | `true` | If `true` the width of the table will be checked (including on resize). If the table width is less than or equal to `autoTrimWidth`, the table will be trimmed. If the width is greater, the table will be untrimmed |
-| `autoTrimWidth` | `640` | Width for auto-trimming. References the width of the table, not the window |
-| `showActiveTitle` | `false` | Should the title of the active header be rendered? |
-| `showSelectControl` | `true` | Should the `select` control be rendered in the active column? |
-| `showPrevControl` | `false` | Should the **Prev** button control be rendered in the active column? |
-| `showNextControl` | `false` | Should the **Next** button control be rendered in the active column? |
-| `prevControlHtml` | `false` | Set custom text for the **Prev** button. |
-| `nextControlHtml` | `false` | Set custom text for the **Next** button. |
-| `activeColCallback` | `null` | Callback function to fire any time the internal `activeCol` state is updated. Takes a single argument (`activeCol` index) |
-| `isTrimmedCallback` | `null` | Callback function to fire any time the internal `isTrimmed` state is updated. Takes a single argument (new `isTrimmed` value) |
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isTrimmed` | `bool` | `false` | Sets whether the table is currently trimmed |
+| `stickyCol` | `int` | `0` | Set the column index which should always be visible when the table is trimmed. |
+| `activeCol` | `int` | `1` | Sets the default active column, or changes the currently active column. |
+| `autoTrimEnabled` | `bool` | `true` | If `true` the width of the table will be checked (including on resize). If the table width is less than or equal to `autoTrimWidth`, the table will be trimmed. If the width is greater, the table will be untrimmed |
+| `autoTrimWidth` | `int` | `640` | Width for auto-trimming. References the width of the table, not the window |
+| `showActiveTitle` | `bool` | `false` | Should the title of the active header be rendered? |
+| `showSelectControl` | `bool` | `true` | Should the `select` control be rendered in the active column? |
+| `showPrevControl` | `bool` | `false` | Should the **Previous** button control be rendered in the active column? |
+| `showNextControl` | `bool` | `false` | Should the **Next** button control be rendered in the active column? |
+| `customPrevControl` | `React Component` | `null` | Custom React component for the **Previous** control element |
+| `customNextControl` | `React Component` | `null` | Custom React component for the **Next** control element |
+| `activeColCallback` | `function` | `null` | Callback function to fire any time the internal `activeCol` state is updated. Takes a single argument (`activeCol` index) |
+| `isTrimmedCallback` | `function` | `null` | Callback function to fire any time the internal `isTrimmed` state is updated. Takes a single argument (new `isTrimmed` value) |
+
 
 ## Styling
 **TableTrim** does not include any styling. It does, however, set multiple classes on the various elements that you can tie your own custom CSS to if you wish.
@@ -99,7 +104,3 @@ In addition to the required `data` prop, **TableTrim** supports a handful of opt
 | `.tt-select`  | The select control in the active column header |
 | `.tt-prev`    | The previous column button control |
 | `.tt-next`    | The next column button control |
-
-
-## License
-MIT © [ponysmith](https://github.com/ponysmith)

--- a/example/public/README.md
+++ b/example/public/README.md
@@ -2,7 +2,11 @@
 
 [![NPM](https://img.shields.io/npm/v/react-tabletrim.svg)](https://www.npmjs.com/package/react-tabletrim) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![ponysmith](https://circleci.com/gh/ponysmith/react-tabletrim.svg?style=shield)](<https://app.circleci.com/github/ponysmith/react-tabletrim/pipelines>)
 
-**react-tabletrim** makes data tables more responsive by allowing you to "trim" the table at smaller widths. When the table is trimmed, the table is reduced to two columns. The **sticky** column is always shown and is always printed as the first column. The second column is the **active** column. The active column can be changed via several optional built-in control elements or by manually setting/updating the `activeCol` prop on the `TableTrim` component.
+
+
+**TableTrim** makes data tables more responsive by allowing you to "trim" the table at smaller widths. When the table is trimmed, the table is reduced to two columns. The **sticky** column is always shown and is always printed as the first column. The second column is the **active** column. The active column can be changed via several optional built-in control elements or by manually setting/updating the `activeCol` prop on the `TableTrim` component.
+
+Visit [http://tabletrim.ponysmith.com](http://tabletrim.ponysmith.com) for more documentation and examples.
 
 ## Install
 
@@ -66,21 +70,22 @@ For **TableTrim** to function properly, both the `header` and `body` objects mus
 ### Optional `props`
 In addition to the required `data` prop, **TableTrim** supports a handful of optional props to customize the behavior of the component. The optional props are detailed below:
 
-| Prop | Default | Description |
-|------|---------|-------------|
-| `isTrimmed` | `false` | Sets whether the table is currently trimmed |
-| `stickyCol` | `0` | Set the column index which should always be visible when the table is trimmed. |
-| `activeCol` | `1` | Sets the default active column, or changes the currently active column. |
-| `autoTrimEnabled` | `true` | If `true` the width of the table will be checked (including on resize). If the table width is less than or equal to `autoTrimWidth`, the table will be trimmed. If the width is greater, the table will be untrimmed |
-| `autoTrimWidth` | `640` | Width for auto-trimming. References the width of the table, not the window |
-| `showActiveTitle` | `false` | Should the title of the active header be rendered? |
-| `showSelectControl` | `true` | Should the `select` control be rendered in the active column? |
-| `showPrevControl` | `false` | Should the **Prev** button control be rendered in the active column? |
-| `showNextControl` | `false` | Should the **Next** button control be rendered in the active column? |
-| `prevControlHtml` | `false` | Set custom text for the **Prev** button. |
-| `nextControlHtml` | `false` | Set custom text for the **Next** button. |
-| `activeColCallback` | `null` | Callback function to fire any time the internal `activeCol` state is updated. Takes a single argument (`activeCol` index) |
-| `isTrimmedCallback` | `null` | Callback function to fire any time the internal `isTrimmed` state is updated. Takes a single argument (new `isTrimmed` value) |
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isTrimmed` | `bool` | `false` | Sets whether the table is currently trimmed |
+| `stickyCol` | `int` | `0` | Set the column index which should always be visible when the table is trimmed. |
+| `activeCol` | `int` | `1` | Sets the default active column, or changes the currently active column. |
+| `autoTrimEnabled` | `bool` | `true` | If `true` the width of the table will be checked (including on resize). If the table width is less than or equal to `autoTrimWidth`, the table will be trimmed. If the width is greater, the table will be untrimmed |
+| `autoTrimWidth` | `int` | `640` | Width for auto-trimming. References the width of the table, not the window |
+| `showActiveTitle` | `bool` | `false` | Should the title of the active header be rendered? |
+| `showSelectControl` | `bool` | `true` | Should the `select` control be rendered in the active column? |
+| `showPrevControl` | `bool` | `false` | Should the **Previous** button control be rendered in the active column? |
+| `showNextControl` | `bool` | `false` | Should the **Next** button control be rendered in the active column? |
+| `customPrevControl` | `React Component` | `null` | Custom React component for the **Previous** control element |
+| `customNextControl` | `React Component` | `null` | Custom React component for the **Next** control element |
+| `activeColCallback` | `function` | `null` | Callback function to fire any time the internal `activeCol` state is updated. Takes a single argument (`activeCol` index) |
+| `isTrimmedCallback` | `function` | `null` | Callback function to fire any time the internal `isTrimmed` state is updated. Takes a single argument (new `isTrimmed` value) |
+
 
 ## Styling
 **TableTrim** does not include any styling. It does, however, set multiple classes on the various elements that you can tie your own custom CSS to if you wish.
@@ -99,7 +104,3 @@ In addition to the required `data` prop, **TableTrim** supports a handful of opt
 | `.tt-select`  | The select control in the active column header |
 | `.tt-prev`    | The previous column button control |
 | `.tt-next`    | The next column button control |
-
-
-## License
-MIT © [ponysmith](https://github.com/ponysmith)

--- a/example/src/Nav.js
+++ b/example/src/Nav.js
@@ -22,8 +22,12 @@ export const Nav = ({ isNavExpanded }) => {
         <span className="link-title">Set Active Column</span>
       </Link>
       <Link className="nav-link" to="/active-col-callback">
-        <span className="link-icon fas fa-sliders-h"></span>
+        <span className="link-icon fas fa-undo-alt"></span>
         <span className="link-title">Active Column Callback</span>
+      </Link>
+      <Link className="nav-link" to="/custom-prevnext">
+        <span className="link-icon fas fa-exchange-alt"></span>
+        <span className="link-title">Custom Prev / Next</span>
       </Link>
     </nav>
   )

--- a/example/src/Page.js
+++ b/example/src/Page.js
@@ -7,6 +7,7 @@ import Main from './pages/Main'
 import Basic from './pages/Basic'
 import ActiveCol from './pages/ActiveCol'
 import ActiveColCallback from './pages/ActiveColCallback'
+import CustomPrevNext from './pages/CustomPrevNext'
 
 export const Page = ({ isNavExpanded }) => {
   return (
@@ -21,6 +22,7 @@ export const Page = ({ isNavExpanded }) => {
           <Route exact path="/basic" component={Basic} />
           <Route exact path="/active-col" component={ActiveCol} />
           <Route exact path="/active-col-callback" component={ActiveColCallback} />
+          <Route exact path="/custom-prevnext" component={CustomPrevNext} />
         </Switch>
         </main>
       </div>

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -72,6 +72,15 @@ tbody td {
   border-left: 1px solid #333;
 }
 
+#example-table .custom-prev,
+#example-table .custom-next {
+  font-size: 18px;
+  color: #3795FF;
+  margin: 0 5px;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
 
 .options-panel {
   display: flex;
@@ -95,7 +104,7 @@ tbody td {
   display: flex;
   align-items: center;
   cursor: pointer;
-  text-align: right;
+  text-align: center;
 }
 .option-toggle .fas.fa-toggle-on {
   font-size: 20px;
@@ -116,7 +125,7 @@ tbody td {
   display: inline-block;
   width: 50px;
   color: #666;
-  text-align: right;
+  text-align: center;
   font-weight: 800;
 }
 .option-title {

--- a/example/src/pages/CustomPrevNext.js
+++ b/example/src/pages/CustomPrevNext.js
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+
+import data from '../data'
+import TableTrim from 'react-tabletrim'
+
+export const CustomPrevNext = () => {
+  /**
+   * State
+   */
+  const [_isTrimmed, setIsTrimmed] = useState(false)
+  const [_useCustomPrev, setUseCustomPrev] = useState(false)
+  const [_useCustomNext, setUseCustomNext] = useState(false)
+
+  /**
+   * Methods
+   */
+  const handleIsTrimmed = () => setIsTrimmed(!_isTrimmed)
+  const handleCustomPrev = () => setUseCustomPrev(!_useCustomPrev)
+  const handleCustomNext = () => setUseCustomNext(!_useCustomNext)
+
+  return (
+    <section>      
+      <h1>Custom Prev / Next buttons</h1>
+      <p>
+        By default, TableTrim renders a <code>select</code> element to choose the active column. However, you can customize TableTrim to render Previous and Next buttons as well / instead. To render the buttons, simply set the <code>showPrevControl</code> and/or <code>showNextControl</code> props to <code>true</code>. This will render the default previous and next <code>button</code> elements.
+      </p>
+
+      <p>
+        In addition to rendering the Previous and Next controls, you can override the default rendering with a custom component. This is helpful if you want to customize the look and feel of the controls beyond basic style changes using the included CSS classes. To override the rendering of the controls, simply pass a custom React component to the appropriate TableTrim prop.
+      </p>
+      
+      <pre>
+        &lt;TableTrim<br />
+          &nbsp;&nbsp;showPrevControl=&#123;true&#125;<br />
+          &nbsp;&nbsp;customPrevControl=&#123; () => (&lt;span&gt;Custom Prev Control&lt;/span&gt;) &#125;<br />
+          &nbsp;&nbsp;/&gt;
+      </pre>
+
+      <p>
+        Your custom component will be rendered as HTML inside the actual Prev/Next control. This means that there is no need to reproduce or override the event handlers for the controls. Everything will continue to work as usual, just with your new, fancy component.
+      </p>
+
+
+      <h2>Example</h2>
+      <div id="example-container">
+        <div id="example-options">
+        <div className="option">
+            <button className="option-toggle" onClick={handleIsTrimmed}>
+              <span className={ (_isTrimmed) ? "fas fa-toggle-on" : "fas fa-toggle-off" }></span>
+              <span className="option-title">isTrimmed</span>
+            </button>
+          </div>
+          <div className="option">
+            <button className="option-toggle" onClick={handleCustomPrev}>
+              <span className={ (_useCustomPrev) ? "fas fa-toggle-on" : "fas fa-toggle-off" }></span>
+              <span className="option-title">customPrevControl</span>
+            </button>
+          </div>
+          <div className="option">
+            <button className="option-toggle" onClick={handleCustomNext}>
+              <span className={ (_useCustomNext) ? "fas fa-toggle-on" : "fas fa-toggle-off" }></span>
+              <span className="option-title">customNextControl</span>
+            </button>
+          </div>
+        </div>
+
+        <div id="example-table" className="example-custom-prevnext">
+          <TableTrim 
+            data={data} 
+            isTrimmed={_isTrimmed}
+            showSelectControl={false}
+            showPrevControl={true}
+            showNextControl={true}
+            customPrevControl={ (_useCustomPrev) ? () => (<i className="fas fa-caret-square-left custom-prev"></i>) : undefined }
+            customNextControl={ (_useCustomNext) ? () => (<i className="fas fa-caret-square-right custom-next"></i>) : undefined }
+            />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CustomPrevNext;

--- a/src/TableTrim.js
+++ b/src/TableTrim.js
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import TableTrimHeader from './TableTrimHeader'
 import TableTrimBody from './TableTrimBody'
-import { validateActiveCol, validateStickyCol } from './TableTrimValidators'
+import { validateActiveCol, validateStickyCol, validateReactComponent } from './TableTrimValidators'
 
 const TableTrim = (props) => {
   /**
@@ -90,8 +90,8 @@ const TableTrim = (props) => {
         showPrevControl={props.showPrevControl}
         showNextControl={props.showNextControl}
         showSelectControl={props.showSelectControl}
-        prevControlHtml={props.prevControlHtml}
-        nextControlHtml={props.nextControlHtml}
+        customPrevControl={props.customPrevControl}
+        customNextControl={props.customNextControl}
         // methods
         setActiveCol={setActiveCol}
         />
@@ -120,8 +120,6 @@ TableTrim.defaultProps = {
   showSelectControl: true,
   showPrevControl: false,
   showNextControl: false,
-  nextControlHtml: 'Next',
-  prevControlHtml: 'Previous',
   showActiveTitle: false,
   activeColCallback: null,
   isTrimmedCallback: null
@@ -144,8 +142,8 @@ TableTrim.propTypes = {
   showSelectControl: PropTypes.bool,
   showPrevControl: PropTypes.bool,
   showNextControl: PropTypes.bool,
-  nextControlHtml: PropTypes.string,
-  prevControlHtml: PropTypes.string,
+  customPrevControl: PropTypes.func,
+  customNextControl: PropTypes.func,
   // callbacks
   activeColCallback: PropTypes.func,
   isTrimmedCallback: PropTypes.func

--- a/src/TableTrimHeader.js
+++ b/src/TableTrimHeader.js
@@ -1,7 +1,16 @@
 import React from 'react'
 import classNames from 'classnames'
 
+const defaultPrevControl = () => (<button>Previous</button>)
+const defaultNextControl = () => (<button>Next</button>)
+
 export const TableTrimHeader = (props) => {
+
+  /**
+   * Overrides
+   */
+  const PrevControl = props.customPrevControl || defaultPrevControl
+  const NextControl = props.customNextControl || defaultNextControl
 
   /**
    * Render methods
@@ -50,11 +59,19 @@ export const TableTrimHeader = (props) => {
   }
 
   const renderPrevControl = () => {
-    return (<button className="tt-prev" onClick={ () => props.setActiveCol(props.prevIndex) }>{ props.prevControlHtml }</button>)
+    return (
+      <span className="tt-prev" onClick={ () => props.setActiveCol(props.prevIndex) }>
+        <PrevControl />
+      </span>
+    )
   }
 
   const renderNextControl = () => {
-    return (<button className="tt-next" onClick={ () => props.setActiveCol(props.nextIndex) }>{ props.nextControlHtml }</button>)
+    return (
+      <span className="tt-next" onClick={ () => props.setActiveCol(props.nextIndex) }>
+        <NextControl />
+      </span>
+    )
   }
 
   const renderSelectControl = (cells) => {

--- a/src/TableTrimHeader.test.js
+++ b/src/TableTrimHeader.test.js
@@ -112,7 +112,7 @@ describe('TableTrimHeader', () => {
     expect(wrapper.find('.tt-select').exists()).toEqual(false);
   })
 
-  it('should render controls if enabled when trimmed', () => {
+  it('should render enabled controls when trimmed', () => {
     const props = { ...minProps, isTrimmed: true, showPrevControl: true, showNextControl: true, showSelectControl: true }
     const wrapper = shallow(<TableTrimHeader { ...props } />);
     expect(wrapper.find('.tt-prev').exists()).toEqual(true);
@@ -120,11 +120,15 @@ describe('TableTrimHeader', () => {
     expect(wrapper.find('.tt-select').exists()).toEqual(true);
   });
 
-  it('should use custom HTML for prev and next controls', () => {
-    const props = { ...minProps, isTrimmed: true, showPrevControl: true, showNextControl: true, prevControlHtml: 'foo', nextControlHtml: 'bar' }
+  it('should use custom components for prev and next controls', () => {
+    const customPrev = () => (<span>customPrev</span>);
+    const customNext = () => (<span>customNext</span>);
+    const props = { ...minProps, isTrimmed: true, showPrevControl: true, showNextControl: true, customPrevControl: customPrev, customNextControl: customNext }
     const wrapper = shallow(<TableTrimHeader { ...props } />);
-    expect(wrapper.find('.tt-prev').text()).toEqual('foo');
-    expect(wrapper.find('.tt-next').text()).toEqual('bar');
+    expect(wrapper.find(customPrev).exists()).toEqual(true);
+    expect(wrapper.find(customNext).exists()).toEqual(true);
+    expect(wrapper.find(customPrev).html()).toEqual('<span>customPrev</span>');
+    expect(wrapper.find(customNext).html()).toEqual('<span>customNext</span>');
   });
 
   it('should select the currently active column in the select control', () => {

--- a/src/TableTrimValidators.js
+++ b/src/TableTrimValidators.js
@@ -1,7 +1,10 @@
+import React from 'react'
+
+
 export const errors = {
   ACTIVECOL_OUT_OF_RANGE: 'activeCol - Out of range',
   STICKYCOL_OUT_OF_RANGE: 'stickyCol - Out of range',
-  ACTIVECOL_STICKYCOL_CONFLICT: 'activeCol and stickyCol cannot be the same'
+  ACTIVECOL_STICKYCOL_CONFLICT: 'activeCol and stickyCol cannot be the same',
 }
 
 export const validateActiveCol = (props, propName) => {


### PR DESCRIPTION
Changing custom prev/next buttons to be components rather than strings for more flexibility.